### PR TITLE
Feature: sub parsing

### DIFF
--- a/src/Handler/SubHydratingHandler.php
+++ b/src/Handler/SubHydratingHandler.php
@@ -1,0 +1,138 @@
+<?php
+namespace MetaHydrator\Handler;
+
+use MetaHydrator\Exception\HydratingException;
+use MetaHydrator\Exception\ValidationException;
+use MetaHydrator\MetaHydrator;
+use MetaHydrator\Reflection\Getter;
+use MetaHydrator\Reflection\GetterInterface;
+use MetaHydrator\Validator\ValidatorInterface;
+use Mouf\Hydrator\Hydrator;
+
+/**
+ * An implementation of HydratingHandlerInterface aiming to manage partial edition of sub-objects
+ *
+ * Class SubHydratingHandler
+ * @package MetaHydrator\Handler
+ */
+class SubHydratingHandler implements HydratingHandlerInterface
+{
+    /** @var string */
+    protected $key;
+    public function getKey() { return $this->key; }
+    public function setKey(string $key) { $this->key = $key; }
+
+    /** @var string */
+    protected $className;
+    public function getClassName() { return $this->className; }
+    public function setClassName(string $className) { $this->className = $className; }
+
+    /** @var Hydrator */
+    protected $hydrator;
+    public function getHydrator() { return $this->hydrator; }
+    public function setHydrator(Hydrator $hydrator) { $this->hydrator = $hydrator; }
+
+    /** @var ValidatorInterface[] */
+    protected $validators;
+    public function getValidators() { return $this->validators; }
+    public function setValidators(array $validators) { $this->validators = $validators; }
+    public function addValidator(ValidatorInterface $validator) { $this->validators[] = $validator; }
+
+    /** @var string */
+    protected $errorMessage;
+    public function getErrorMessage() { return $this->errorMessage; }
+    public function setErrorMessage(string $errorMessage) { $this->errorMessage = $errorMessage; }
+
+    /** @var GetterInterface */
+    protected $getter;
+    public function getGetter() { return $this->getter; }
+    public function setGetter(GetterInterface $getter) { $this->getter = $getter; }
+
+    /**
+     * SubHydratingHandler constructor.
+     * @param string $key
+     * @param string $className
+     * @param Hydrator $hydrator
+     * @param ValidatorInterface[] $validators
+     * @param string $errorMessage
+     * @param GetterInterface $getter
+     */
+    public function __construct(string $key, string $className, Hydrator $hydrator, array $validators = [], string $errorMessage = "", GetterInterface $getter = null)
+    {
+        $this->key = $key;
+        $this->className = $className;
+        $this->hydrator = $hydrator;
+        $this->validators = $validators;
+        $this->errorMessage = $errorMessage;
+        $this->getter = $getter ?? new Getter(false);
+    }
+
+    /**
+     * @param array $data
+     * @param array $targetData
+     * @param $object
+     *
+     * @throws HydratingException
+     */
+    public function handle(array $data, array &$targetData, $object = null)
+    {
+        if (!array_key_exists($this->key, $data)) {
+            if ($object !== null) {
+                return;
+            } else {
+                $subObject = null;
+                $targetData[$this->key] = $subObject;
+            }
+        } elseif ($data[$this->key] === null) {
+            $subObject = null;
+            $targetData[$this->key] = null;
+        } elseif (!is_array($data[$this->key])) {
+            throw new HydratingException([$this->key => $this->errorMessage]);
+        } else {
+            $subData = $data[$this->key];
+
+            try {
+                $subObject = $this->getSubObject($object);
+                if ($subObject !== null) {
+                    $this->hydrator->hydrateObject($subData, $subObject);
+                } else {
+                    $subObject = $this->hydrator->hydrateNewObject($subData, $this->className);
+                    $targetData[$this->key] = $subObject;
+                }
+            } catch (HydratingException $exception) {
+                throw new HydratingException([$this->key => $exception->getErrorsMap()]);
+            }
+        }
+
+        $this->validate($subObject, $object);
+    }
+
+    /**
+     * @param mixed $parsedValue
+     * @param mixed $contextObject
+     *
+     * @throws HydratingException
+     */
+    private function validate($parsedValue, $contextObject = null)
+    {
+        try {
+            foreach ($this->validators as $validator) {
+                $validator->validate($parsedValue, $contextObject);
+            }
+        } catch (ValidationException $exception) {
+            throw new HydratingException([ $this->key => $exception->getInnerError() ]);
+        }
+    }
+
+    /**
+     * @param $object
+     * @return mixed
+     */
+    protected function getSubObject($object)
+    {
+        if ($object === null) {
+            return null;
+        }
+        return $this->getter->get($object, $this->key);
+    }
+}

--- a/src/Parser/ArrayParser.php
+++ b/src/Parser/ArrayParser.php
@@ -28,7 +28,7 @@ class ArrayParser extends AbstractParser
      * @param ValidatorInterface[] $subValidators
      * @param string $errorMessage
      */
-    public function __construct(ParserInterface $subParser, $subValidators = [], $errorMessage = "")
+    public function __construct(ParserInterface $subParser, array $subValidators = [], string $errorMessage = "")
     {
         parent::__construct($errorMessage);
         $this->subParser = $subParser;

--- a/src/Parser/ObjectParser.php
+++ b/src/Parser/ObjectParser.php
@@ -1,0 +1,65 @@
+<?php
+namespace MetaHydrator\Parser;
+
+use MetaHydrator\Exception\HydratingException;
+use MetaHydrator\Exception\ParsingException;
+use MetaHydrator\Handler\HydratingHandlerInterface;
+use MetaHydrator\MetaHydrator;
+use MetaHydrator\Validator\ValidatorInterface;
+use Mouf\Hydrator\Hydrator;
+use Mouf\Hydrator\TdbmHydrator;
+
+/**
+ * A custom class parser based on the MetaHydrator behaviour
+ *
+ * Class ObjectParser
+ * @package MetaHydrator\Parser
+ */
+class ObjectParser extends AbstractParser implements ParserInterface
+{
+    /** @var string */
+    private $className;
+    public function getClassName() { return $this->className;}
+    public function setClassName(string $className) { $this->className = $className; }
+
+    /** @var Hydrator */
+    private $hydrator;
+    public function getHydrator() { return $this->hydrator; }
+    public function setHydrator(Hydrator $hydrator) { $this->hydrator = $hydrator; }
+
+    /**
+     * ObjectParser constructor.
+     * @param string $className
+     * @param Hydrator $hydrator
+     * @param string $errorMessage
+     */
+    public function __construct(string $className, Hydrator $hydrator, string $errorMessage = "")
+    {
+        parent::__construct($errorMessage);
+        $this->className = $className;
+        $this->hydrator = $hydrator;
+    }
+
+
+    /**
+     * @param $rawValue
+     * @return mixed
+     *
+     * @throws ParsingException
+     */
+    public function parse($rawValue)
+    {
+        if ($rawValue === null) {
+            return null;
+        }
+        if (!is_array($rawValue)) {
+            $this->throw();
+        }
+
+        try {
+            return $this->hydrator->hydrateNewObject($rawValue, $this->className);
+        } catch (HydratingException $exception) {
+            throw new ParsingException($exception->getErrorsMap());
+        }
+    }
+}

--- a/src/Reflection/Getter.php
+++ b/src/Reflection/Getter.php
@@ -1,0 +1,138 @@
+<?php
+namespace MetaHydrator\Reflection;
+
+use ArrayAccess;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+
+class Getter implements GetterInterface
+{
+    /** @var bool */
+    protected $throwOnFail;
+
+    /** @var bool */
+    protected $ignoreProtected;
+
+    /**
+     * Getter constructor.
+     * @param bool $throwOnFail
+     * @param bool $ignoreProtected
+     */
+    public function __construct(bool $throwOnFail = true, bool $ignoreProtected = false)
+    {
+        $this->throwOnFail = $throwOnFail;
+        $this->ignoreProtected = $ignoreProtected;
+    }
+
+    /**
+     * @param $object
+     * @param string $field
+     * @return mixed
+     */
+    public function get($object, string $field)
+    {
+        if (is_array($object)) {
+            return $this->getFromArray($object, $field);
+        }
+
+        if (is_object($object)) {
+            return $this->getFromObject($object, $field);
+        }
+
+        if ($this->throwOnFail) {
+            throw new ReflectionException("cannot extract field '$field' from non-object, non-array value");
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param $object
+     * @param string $field
+     * @return null
+     * @throws ReflectionException
+     */
+    protected function getFromArray($object, string $field)
+    {
+        if (array_key_exists($field, $object)) {
+            return $object[$field];
+        } else if ($this->throwOnFail) {
+            throw new ReflectionException("cannot extract field '$field' from array");
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param $object
+     * @param string $field
+     * @return mixed|null
+     * @throws ReflectionException
+     */
+    protected function getFromObject($object, string $field)
+    {
+        $reflectionClass = new ReflectionClass($object);
+
+        $getterMethod = $this->findGetterMethod($reflectionClass, $field);
+        if ($getterMethod !== null) {
+            return $getterMethod->invoke($object);
+        }
+
+        $property = $this->findProperty($reflectionClass, $field);
+        if ($property !== null) {
+            return $property->getValue($object);
+        }
+
+        if ($object instanceof ArrayAccess && $object->offsetExists($field)) {
+            return $object->offsetGet($field);
+        }
+
+        if ($this->throwOnFail) {
+            throw new ReflectionException("cannot extract field '$field' from object");
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param ReflectionClass $reflectionClass
+     * @param string $field
+     * @return null|ReflectionMethod
+     */
+    protected function findGetterMethod(ReflectionClass $reflectionClass, string $field)
+    {
+        foreach ($reflectionClass->getMethods($this->ignoreProtected ? ReflectionMethod::IS_PUBLIC|ReflectionMethod::IS_PROTECTED|ReflectionMethod::IS_PRIVATE : ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
+            if (!$reflectionMethod->isStatic()
+                && $reflectionMethod->getNumberOfRequiredParameters() == 0
+                && strcasecmp($reflectionMethod->getName(), "get$field") == 0) {
+                if (!$reflectionMethod->isPublic()) {
+                    $reflectionMethod->setAccessible(true);
+                }
+                return $reflectionMethod;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param ReflectionClass $reflectionClass
+     * @param string $field
+     * @return null|\ReflectionProperty
+     */
+    protected function findProperty(ReflectionClass $reflectionClass, string $field)
+    {
+        if ($reflectionClass->hasProperty($field)) {
+            $property = $reflectionClass->getProperty($field);
+            if (!$property->isStatic()) {
+                if ($property->isPublic()) {
+                    return $property;
+                } else if ($this->ignoreProtected) {
+                    $property->setAccessible(true);
+                    return $property;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/Reflection/GetterInterface.php
+++ b/src/Reflection/GetterInterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace MetaHydrator\Reflection;
+
+/**
+ * interface to retrieve a value from an object, given a field name
+ *
+ * Interface GetterInterface
+ * @package MetaHydrator\Reflection
+ */
+interface GetterInterface
+{
+    /**
+     * @param $object
+     * @param string $field
+     * @return mixed
+     */
+    public function get($object, string $field);
+}

--- a/src/Reflection/Setter.php
+++ b/src/Reflection/Setter.php
@@ -1,0 +1,121 @@
+<?php
+namespace MetaHydrator\Reflection;
+
+use ArrayAccess;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+
+class Setter implements SetterInterface
+{
+    /** @var bool */
+    protected $throwOnFail;
+
+    /** @var bool */
+    protected $ignoreProtected;
+
+    /**
+     * Setter constructor.
+     * @param bool $throwOnFail
+     * @param bool $ignoreProtected
+     */
+    public function __construct(bool $throwOnFail = true, bool $ignoreProtected = false)
+    {
+        $this->throwOnFail = $throwOnFail;
+        $this->ignoreProtected = $ignoreProtected;
+    }
+
+    /**
+     * @param $object
+     * @param string $field
+     * @param mixed $value
+     */
+    public function set(&$object, string $field, $value)
+    {
+        if (is_array($object)) {
+            $this->setInArray($object, $field, $value);
+            return;
+        }
+
+        if (is_object($object)) {
+            $this->setInObject($object, $field, $value);
+            return;
+        }
+
+        if ($this->throwOnFail) {
+            throw new ReflectionException("cannot set field '$field' in non-object, non-array value");
+        }
+    }
+
+    protected function setInArray(&$object, string $field, $value)
+    {
+        $object[$field] = $value;
+    }
+
+    protected function setInObject(&$object, string $field, $value)
+    {
+        $reflectionClass = new ReflectionClass($object);
+
+        $setterMethod = $this->findSetterMethod($reflectionClass, $field);
+        if ($setterMethod !== null) {
+            $setterMethod->invoke($object, $value);
+            return;
+        }
+
+        $property = $this->findProperty($reflectionClass, $field);
+        if ($property !== null) {
+            $property->setValue($object, $value);
+            return;
+        }
+
+        if ($object instanceof ArrayAccess) {
+            $object->offsetSet($field, $value);
+            return;
+        }
+
+        if ($this->throwOnFail) {
+            throw new ReflectionException("cannot set field '$field' in object");
+        }
+    }
+
+    /**
+     * @param ReflectionClass $reflectionClass
+     * @param string $field
+     * @return null|ReflectionMethod
+     */
+    protected function findSetterMethod(ReflectionClass $reflectionClass, string $field)
+    {
+        foreach ($reflectionClass->getMethods($this->ignoreProtected ? ReflectionMethod::IS_PUBLIC|ReflectionMethod::IS_PROTECTED|ReflectionMethod::IS_PRIVATE : ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
+            if (!$reflectionMethod->isStatic()
+                && $reflectionMethod->getNumberOfRequiredParameters() == 1
+                && strcasecmp($reflectionMethod->getName(), "set$field") == 0) {
+                if (!$reflectionMethod->isPublic()) {
+                    $reflectionMethod->setAccessible(true);
+                }
+                return $reflectionMethod;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param ReflectionClass $reflectionClass
+     * @param string $field
+     * @return null|\ReflectionProperty
+     */
+    protected function findProperty(ReflectionClass $reflectionClass, string $field)
+    {
+        if ($reflectionClass->hasProperty($field)) {
+            $property = $reflectionClass->getProperty($field);
+            if (!$property->isStatic()) {
+                if ($property->isPublic()) {
+                    return $property;
+                } else if ($this->ignoreProtected) {
+                    $property->setAccessible(true);
+                    return $property;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/Reflection/SetterInterface.php
+++ b/src/Reflection/SetterInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace MetaHydrator\Reflection;
+
+/**
+ * Interface SetterInterface
+ * @package MetaHydrator\Reflection
+ */
+interface SetterInterface
+{
+    /**
+     * @param $object
+     * @param string $field
+     * @param mixed $value
+     */
+    public function set(&$object, string $field, $value);
+}

--- a/tests/FooBar.php
+++ b/tests/FooBar.php
@@ -1,8 +1,18 @@
 <?php
 namespace MetaHydratorTest;
 
+use MetaHydrator\Reflection\Setter;
+
 class FooBar implements \JsonSerializable
 {
+    public function __construct($values = [])
+    {
+        $setter = new Setter(false);
+        foreach ($values as $key => $value) {
+            $setter->set($this, $key, $value);
+        }
+    }
+
     /** @var string */
     private $foo;
     /** @return string */
@@ -31,11 +41,11 @@ class FooBar implements \JsonSerializable
     /** @var FooBar $qux */
     public function setQux($qux) { $this->qux = $qux; }
 
-    /** @var string */
+    /** @var FooBar */
     private $quux;
-    /** @return string */
+    /** @return FooBar */
     public function getQuux() { return $this->quux; }
-    /** @var string $quux */
+    /** @var FooBar $quux */
     public function setQuux($quux) { $this->quux = $quux; }
 
     /** @var string */
@@ -45,25 +55,25 @@ class FooBar implements \JsonSerializable
     /** @var string $corge */
     public function setCorge($corge) { $this->corge = $corge; }
 
-    /** @var string */
+    /** @var int[] */
     private $grault;
-    /** @return string */
+    /** @return int[] */
     public function getGrault() { return $this->grault; }
-    /** @var string $grault */
+    /** @var int[] $grault */
     public function setGrault($grault) { $this->grault = $grault; }
 
-    /** @var string */
+    /** @var FooBar[] */
     private $garply;
-    /** @return string */
+    /** @return FooBar[] */
     public function getGarply() { return $this->garply; }
-    /** @var string $garply */
+    /** @var string FooBar[] */
     public function setGarply($garply) { $this->garply = $garply; }
 
-    /** @var string */
+    /** @var FooBar */
     private $waldo;
-    /** @return string */
+    /** @return FooBar */
     public function getWaldo() { return $this->waldo; }
-    /** @var string $waldo */
+    /** @var FooBar $waldo */
     public function setWaldo($waldo) { $this->waldo = $waldo; }
 
     /** @var string */

--- a/tests/Parser/ObjectParserTest.php
+++ b/tests/Parser/ObjectParserTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace MetaHydratorTest\Parser;
+
+use MetaHydrator\Exception\ParsingException;
+use MetaHydrator\Handler\SimpleHydratingHandler;
+use MetaHydrator\MetaHydrator;
+use MetaHydrator\Parser\ObjectParser;
+use MetaHydrator\Parser\StringParser;
+use MetaHydrator\Validator\NotEmptyValidator;
+use MetaHydratorTest\FooBar;
+
+class ObjectParserTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ObjectParser */
+    private $parser;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->parser = new ObjectParser(FooBar::class, new MetaHydrator([
+            new SimpleHydratingHandler('foo', new StringParser(), [new NotEmptyValidator()]),
+        ], []), 'This cannot be a FooBar');
+    }
+
+    public function testParseValidObject()
+    {
+        try {
+            $parsed = $this->parser->parse([
+                'foo' => 'malesuada'
+            ]);
+            self::assertTrue($parsed instanceof FooBar);
+            self::assertTrue($parsed->getFoo() == 'malesuada');
+        } catch (ParsingException $exception) {
+            self::assertFalse(true);
+        }
+    }
+
+    public function testParseInvalidObject()
+    {
+        try {
+            $parsed = $this->parser->parse([
+                'foo' => null,
+            ]);
+            self::assertFalse(true);
+        } catch (ParsingException $exception) {
+            self::assertArrayHasKey('foo', $exception->getInnerError());
+
+            return;
+        }
+        self::assertFalse(true);
+    }
+
+    public function testParseInvalidType()
+    {
+        try {
+            $parsed = $this->parser->parse('ALL WRONG');
+            self::assertFalse(true);
+        } catch (ParsingException $exception) {
+            self::assertTrue($exception->getInnerError() === 'This cannot be a FooBar');
+
+            return;
+        }
+        self::assertFalse(true);
+    }
+}

--- a/tests/Reflection/GetterTest.php
+++ b/tests/Reflection/GetterTest.php
@@ -1,0 +1,190 @@
+<?php
+namespace MetaHydratorTest\Reflection;
+
+use MetaHydrator\Reflection\Getter;
+
+class GetterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetPublicGetter()
+    {
+        $getter = new Getter();
+        $object = new class {
+            public function getValue() { return 3; }
+        };
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(3, $value);
+    }
+
+    public function testGetPrivateGetter()
+    {
+        $getter = new Getter(true, true);
+        $object = new class {
+            private function getValue() { return 3; }
+        };
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(3, $value);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetPrivateGetterThrow()
+    {
+        $getter = new Getter();
+        $object = new class {
+            private function getValue() { return 3; }
+        };
+        $getter->get($object, 'value');
+    }
+
+    public function testGetPrivateGetterIgnore()
+    {
+        $getter = new Getter(false);
+        $object = new class {
+            private function getValue() { return 3; }
+        };
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(null, $value);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetStaticGetterThrow()
+    {
+        $getter = new Getter();
+        $object = new class {
+            static function getValue() { return 3; }
+        };
+        $getter->get($object, 'value');
+    }
+
+    public function testGetPublicProperty()
+    {
+        $getter = new Getter();
+        $object = new class {
+            public $value = 3;
+        };
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(3, $value);
+    }
+
+    public function testGetPrivateProperty()
+    {
+        $getter = new Getter(true, true);
+        $object = new class {
+            private $value = 3;
+        };
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(3, $value);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetPrivatePropertyThrow()
+    {
+        $getter = new Getter();
+        $object = new class {
+            private $value = 3;
+        };
+        $getter->get($object, 'value');
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetStaticPropertyThrow()
+    {
+        $getter = new Getter();
+        $object = new class {
+            static $value = 3;
+        };
+        $getter->get($object, 'value');
+    }
+
+    public function testGetFromArray()
+    {
+        $getter = new Getter();
+        $object = [
+            'value' => 3
+        ];
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(3, $value);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetFromArrayThrow()
+    {
+        $getter = new Getter();
+        $object = [];
+        $getter->get($object, 'value');
+    }
+
+    public function testGetFromArrayIgnore()
+    {
+        $getter = new Getter(false);
+        $object = [];
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(null, $value);
+    }
+
+    public function testGetFromArrayAccess()
+    {
+        $getter = new Getter();
+        $object = new class implements \ArrayAccess {
+            public function offsetExists($offset) { return $offset === "value"; }
+            public function offsetGet($offset) { return 3; }
+            public function offsetSet($offset, $value) { }
+            public function offsetUnset($offset) { }
+        };
+        $getter->get($object, 'value');
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetFromArrayAccessThrow()
+    {
+        $getter = new Getter();
+        $object = new class implements \ArrayAccess {
+            public function offsetExists($offset) { return false; }
+            public function offsetGet($offset) { return 3; }
+            public function offsetSet($offset, $value) { }
+            public function offsetUnset($offset) { }
+        };
+        $getter->get($object, 'value');
+    }
+
+    public function testGetFromArrayAccessIgnore()
+    {
+        $getter = new Getter(false);
+        $object = new class implements \ArrayAccess {
+            public function offsetExists($offset) { return false; }
+            public function offsetGet($offset) { return 3; }
+            public function offsetSet($offset, $value) { }
+            public function offsetUnset($offset) { }
+        };
+        $getter->get($object, 'value');
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testGetFromInvalidThrow()
+    {
+        $getter = new Getter();
+        $object = 3;
+        $getter->get($object, 'value');
+    }
+
+    public function testGetFromInvalidIgnore()
+    {
+        $getter = new Getter(false);
+        $object = 3;
+        $value = $getter->get($object, 'value');
+        $this->assertEquals(null, $value);
+    }
+}

--- a/tests/Reflection/SetterTest.php
+++ b/tests/Reflection/SetterTest.php
@@ -1,0 +1,152 @@
+<?php
+namespace MetaHydratorTest\Reflection;
+
+use MetaHydrator\Reflection\Setter;
+
+class SetterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetPublicSetter()
+    {
+        $setter = new Setter();
+        $object = new class {
+            public $__;
+            public function setValue($value) { $this->__ = $value; }
+        };
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(3, $object->__);
+    }
+
+    public function testSetPrivateSetter()
+    {
+        $setter = new Setter(true, true);
+        $object = new class {
+            public $__;
+            private function setValue($value) { $this->__ = $value; }
+        };
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(3, $object->__);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testSetPrivateSetterThrow()
+    {
+        $setter = new Setter();
+        $object = new class {
+            public $__;
+            private function setValue($value) { $this->__ = $value; }
+        };
+        $setter->set($object, 'value', 3);
+    }
+
+    public function testSetPrivateSetterIgnore()
+    {
+        $setter = new Setter(false);
+        $object = new class {
+            public $__;
+            private function setValue($value) { $this->__ = $value; }
+        };
+        $setter->set($object, 'value', 3);
+        $this->assertNotEquals(3, $object->__);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testSetStaticSetterThrow()
+    {
+        $setter = new Setter();
+        $object = new class {
+            static function setValue($value) { throw new \Exception('Who is the one who knocks?'); }
+        };
+        $setter->set($object, 'value', 3);
+    }
+
+    public function testSetPublicProperty()
+    {
+        $setter = new Setter();
+        $object = new class {
+            public $value = 3;
+        };
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(3, $object->value);
+    }
+
+    public function testSetPrivateProperty()
+    {
+        $setter = new Setter(true, true);
+        $object = new class {
+            private $value = 3;
+            public function __() { return $this->value; }
+        };
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(3, $object->__());
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testSetPrivatePropertyThrow()
+    {
+        $setter = new Setter();
+        $object = new class {
+            private $value = 3;
+        };
+        $setter->set($object, 'value', 3);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testSetStaticPropertyThrow()
+    {
+        $setter = new Setter();
+        $object = new class {
+            static $value = 3;
+        };
+        $setter->set($object, 'value', 3);
+    }
+
+    public function testSetInArray()
+    {
+        $setter = new Setter();
+        $object = [
+            'value' => 3
+        ];
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(3, $object['value']);
+    }
+
+    public function testSetInArrayAccess()
+    {
+        $setter = new Setter();
+        $object = new class implements \ArrayAccess {
+            public $__ = [];
+            public function offsetExists($offset) { return array_key_exists($offset, $this->__); }
+            public function offsetGet($offset) { return $this->__[$offset]; }
+            public function offsetSet($offset, $value) { $this->__[$offset] = $value; }
+            public function offsetUnset($offset) { unset($this->__[$offset]); }
+        };
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(3, $object['value']);
+    }
+
+    /**
+     * @expectedException \ReflectionException
+     */
+    public function testSetFromInvalidThrow()
+    {
+        $setter = new Setter();
+        $object = 2;
+        $setter->set($object, 'value', 3);
+    }
+
+    public function testSetFromInvalidIgnore()
+    {
+        $setter = new Setter(false);
+        $object = 2;
+        $setter->set($object, 'value', 3);
+        $this->assertEquals(2, $object);
+    }
+}


### PR DESCRIPTION
Added classes for handling sub-parsing:
- `ArrayParser` (275d6c45edd1308605ff803c96cf0acd56ab65d9): generic array parser (type deduced from field `$subParser`)
- `ObjectParser` (d008f2667e4f98ce357dc081098523caacbd97c9): generic object parser, reusing `MetaHydrator` behaviour
- `SubHydratingHandler` (d2dcda877d02c66d626d59c9297943b1e48e60b1): like `ObjectParser`, except original object is editted if not null, instead of always creating a new one (ie partial edition possible)