### PR TITLE
Mouf compatibility

### DIFF
--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -11,14 +11,14 @@ use MetaHydrator\Exception\ParsingException;
  */
 abstract class AbstractParser implements ParserInterface
 {
-    /** @var mixed */
+    /** @var string */
     private $errorMessage;
-    /** @return mixed */
+    /** @return string */
     public function getErrorMessage() { return $this->errorMessage; }
 
     /**
      * AbstractValidator constructor.
-     * @param mixed $errorMessage
+     * @param string $errorMessage
      */
     public function __construct($errorMessage = "")
     {

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -11,14 +11,14 @@ use MetaHydrator\Exception\ValidationException;
  */
 abstract class AbstractValidator implements ValidatorInterface
 {
-    /** @var mixed */
+    /** @var string */
     private $errorMessage;
-    /** @return mixed */
+    /** @return string */
     public function getErrorMessage() { return $this->errorMessage; }
 
     /**
      * AbstractValidator constructor.
-     * @param mixed $errorMessage
+     * @param string $errorMessage
      */
     public function __construct($errorMessage = "")
     {


### PR DESCRIPTION
`AbstractParser`/`AbstractValidator`: error messages typed as `string` in PHPDoc (instead of `mixed`)