### PR TITLE
Feature: sub array handler

### DIFF
--- a/src/Handler/SubArrayHydratingHandler.php
+++ b/src/Handler/SubArrayHydratingHandler.php
@@ -1,0 +1,195 @@
+<?php
+namespace MetaHydrator\Handler;
+
+use MetaHydrator\Exception\HydratingException;
+use MetaHydrator\Exception\ValidationException;
+use MetaHydrator\Reflection\Getter;
+use MetaHydrator\Reflection\GetterInterface;
+use MetaHydrator\Validator\ValidatorInterface;
+use Mouf\Hydrator\Hydrator;
+
+/**
+ * Class SubArrayHydratingHandler
+ * @package MetaHydrator\Handler
+ */
+class SubArrayHydratingHandler implements HydratingHandlerInterface
+{
+    /** @var string */
+    protected $key;
+    public function getKey() { return $this->key; }
+    public function setKey(string $key) { $this->key = $key; }
+
+    /** @var string */
+    protected $className;
+    public function getClassName() { return $this->className; }
+    public function setClassName(string $className) { $this->className = $className; }
+
+    /** @var Hydrator */
+    protected $hydrator;
+    public function getHydrator() { return $this->hydrator; }
+    public function setHydrator(Hydrator $hydrator) { $this->hydrator = $hydrator; }
+
+    /** @var string */
+    protected $errorMessage;
+    public function getErrorMessage() { return $this->errorMessage; }
+    public function setErrorMessage(string $errorMessage) { $this->errorMessage = $errorMessage; }
+
+    /** @var string */
+    private $subErrorMessage;
+    public function getSubErrorMessage() { return $this->subErrorMessage; }
+    public function setSubErrorMessage($subErrorMessage) { $this->subErrorMessage = $subErrorMessage; }
+
+    /** @var ValidatorInterface[] */
+    private $validators;
+    public function getValidators() { return $this->validators; }
+    public function setValidators(array $validators) { $this->validators = $validators; }
+    public function addValidator(ValidatorInterface $validator) { $this->validators[] = $validator; }
+
+    /** @var GetterInterface */
+    protected $getter;
+    public function getGetter() { return $this->getter; }
+    public function setGetter(GetterInterface $getter) { $this->getter = $getter; }
+
+    /** @var bool */
+    private $associative;
+    public function getAssociative() { return $this->associative; }
+    public function setAssociative(bool $associative) { $this->associative = $associative; }
+
+    /**
+     * SubArrayHydratingHandler constructor.
+     * @param string $key
+     * @param string $className
+     * @param Hydrator $hydrator
+     * @param ValidatorInterface[] $validators
+     * @param string $errorMessage
+     * @param string $subErrorMessage
+     * @param GetterInterface $getter
+     * @param bool $associative
+     */
+    public function __construct(string $key, string $className, Hydrator $hydrator, array $validators = [], string $errorMessage = "", string $subErrorMessage = "", GetterInterface $getter = null, bool $associative = false)
+    {
+        $this->key = $key;
+        $this->className = $className;
+        $this->hydrator = $hydrator;
+        $this->validators = $validators;
+        $this->errorMessage = $errorMessage;
+        $this->subErrorMessage = $subErrorMessage;
+        $this->getter = $getter ?? new Getter(false);
+        $this->associative = $associative;
+    }
+
+    /**
+     * @param array $data
+     * @param array $targetData
+     * @param $object
+     *
+     * @throws HydratingException
+     */
+    public function handle(array $data, array &$targetData, $object = null)
+    {
+        if (!array_key_exists($this->key, $data)) {
+            if ($object !== null) {
+                return;
+            } else {
+                $subArray = null;
+            }
+        } elseif ($data[$this->key] === null) {
+            $subArray = null;
+        } elseif (!is_array($data[$this->key])) {
+            throw new HydratingException([$this->key => $this->errorMessage]);
+        } else {
+            $subArrayData = $data[$this->key];
+            $subArray = $this->getSubArray($object) ?? null;
+            $errorsMap = [];
+            $ok = true;
+            foreach ($subArrayData as $key => $subData) {
+                $ok = $this->handleSub($key, $subData, $subArray, $errorsMap) && $ok;
+            }
+            if (!$ok) {
+                throw new HydratingException([$this->key => $errorsMap]);
+            }
+        }
+
+        $this->validate($subArray, $object);
+
+        if ($this->associative) {
+            $targetData[$this->key] = $subArray;
+        } elseif ($subArray !== null) {
+            $targetData[$this->key] = array_values($subArray);
+        } else {
+            $targetData[$this->key] = null;
+        }
+    }
+
+    /**
+     * @param string $key
+     * @param array|null $data
+     * @param array $array
+     * @param array $errorsMap
+     * @return bool
+     */
+    protected function handleSub($key, $data, &$array, &$errorsMap)
+    {
+        if ($data === null) {
+            if (array_key_exists($key, $array)) {
+                unset($array[$key]);
+            }
+            $errorsMap[$key] = null;
+            return true;
+        }
+        if (!is_array($data)) {
+            $errorsMap[$key] = $this->subErrorMessage;
+            return false;
+        }
+        if (isset($array[$key])) {
+            $subObject = $array[$key];
+            try {
+                $this->hydrator->hydrateObject($data, $subObject);
+                $errorsMap[$key] = null;
+                return true;
+            } catch (HydratingException $exception) {
+                $errorsMap[$key] = $exception->getErrorsMap();
+                return false;
+            }
+        } else {
+            try {
+                $subObject = $this->hydrator->hydrateNewObject($data, $this->className);
+                $array[$key] = $subObject;
+                $errorsMap[$key] = null;
+                return true;
+            } catch (HydratingException $exception) {
+                $errorsMap[$key] = $exception->getErrorsMap();
+                return false;
+            }
+        }
+    }
+
+    /**
+     * @param $object
+     * @return array
+     */
+    protected function getSubArray($object)
+    {
+        if ($object === null) {
+            return [];
+        }
+        return $this->getter->get($object, $this->key);
+    }
+
+    /**
+     * @param mixed $parsedValue
+     * @param mixed $contextObject
+     *
+     * @throws HydratingException
+     */
+    private function validate($parsedValue, $contextObject = null)
+    {
+        try {
+            foreach ($this->validators as $validator) {
+                $validator->validate($parsedValue, $contextObject);
+            }
+        } catch (ValidationException $exception) {
+            throw new HydratingException([ $this->key => $exception->getInnerError() ]);
+        }
+    }
+}

--- a/tests/Handler/SubArrayHydratingHandlerTest.php
+++ b/tests/Handler/SubArrayHydratingHandlerTest.php
@@ -1,0 +1,340 @@
+<?php
+namespace MetaHydratorTest;
+
+use MetaHydrator\Exception\HydratingException;
+use MetaHydrator\Handler\SimpleHydratingHandler;
+use MetaHydrator\Handler\SubArrayHydratingHandler;
+use MetaHydrator\MetaHydrator;
+use MetaHydrator\Parser\IntParser;
+use MetaHydrator\Parser\StringParser;
+use MetaHydrator\Validator\NotEmptyValidator;
+
+class SubArrayHydratingHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var MetaHydrator */
+    private $hydrator;
+
+    public function setUp()
+    {
+        $this->hydrator = new MetaHydrator([
+            new SimpleHydratingHandler('foo', new StringParser('Invalid string')),
+            new SubArrayHydratingHandler('garply', FooBar::class,
+                new MetaHydrator([
+                    new SimpleHydratingHandler('foo', new StringParser('Invalid string')),
+                    new SimpleHydratingHandler('bar', new IntParser('Invalid integer'))
+                ]), [], 'Invalid array', 'Invalid FooBar'
+            )
+        ]);
+    }
+
+    public function testHydrateNew()
+    {
+        $data = [
+            'foo' => 'Joe',
+            'garply' => [
+                [ 'foo' => 'Jack' ],
+                null,
+                [ 'foo' => 'Averell' ],
+            ]
+        ];
+
+        /** @var FooBar $fooBar */
+        $fooBar = $this->hydrator->hydrateNewObject($data, FooBar::class);
+
+        $this->assertEquals('Joe', $fooBar->getFoo());
+
+        $garplies = $fooBar->getGarply();
+        $this->assertCount(2, $garplies);
+
+        $this->assertEquals('Jack', $garplies[0]->getFoo());
+        $this->assertEquals('Averell', $garplies[1]->getFoo());
+    }
+
+    public function testHydrateNewEmpty()
+    {
+        $data = [
+            'foo' => 'Joe',
+            'garply' => []
+        ];
+
+        /** @var FooBar $fooBar */
+        $fooBar = $this->hydrator->hydrateNewObject($data, FooBar::class);
+        $garplies = $fooBar->getGarply();
+        $this->assertSame([], $garplies);
+    }
+
+    public function testHydrateNewNull()
+    {
+        $data = [
+            'foo' => 'Joe',
+            'garply' => null
+        ];
+
+        /** @var FooBar $fooBar */
+        $fooBar = $this->hydrator->hydrateNewObject($data, FooBar::class);
+        $garplies = $fooBar->getGarply();
+        $this->assertSame(null, $garplies);
+    }
+
+    public function testHydrateNewUndefined()
+    {
+        $data = [
+            'foo' => 'Joe'
+        ];
+
+        /** @var FooBar $fooBar */
+        $fooBar = $this->hydrator->hydrateNewObject($data, FooBar::class);
+        $garplies = $fooBar->getGarply();
+        $this->assertSame(null, $garplies);
+    }
+
+    /**
+     * @expectedException \MetaHydrator\Exception\HydratingException
+     */
+    public function testHydrateNewInvalid()
+    {
+        $data = [
+            'foo' => 'Joe',
+            'garply' => 'array(0)[]'
+        ];
+
+        $this->hydrator->hydrateNewObject($data, FooBar::class);
+    }
+
+    public function testHydrateObject()
+    {
+        $data = [
+            'garply' => [
+                1 => null,
+                2 => [
+                    'foo' => 'Ma'
+                ]
+            ]
+        ];
+
+        $fooBar = $this->getFooBar();
+        $this->hydrator->hydrateObject($data, $fooBar);
+
+        $garplies = $fooBar->getGarply();
+        $this->assertCount(2, $garplies);
+        $this->assertEquals('Jack', $garplies[0]->getFoo());
+        $this->assertEquals('Ma', $garplies[1]->getFoo());
+    }
+
+    public function testHydrateObjectEmpty()
+    {
+        $fooBar = $this->getFooBar();
+
+        $data = [
+            'garply' => []
+        ];
+
+        $this->hydrator->hydrateObject($data, $fooBar);
+
+        $garplies = $fooBar->getGarply();
+        $this->assertCount(3, $garplies);
+        $this->assertEquals('Jack', $garplies[0]->getFoo());
+        $this->assertEquals('William', $garplies[1]->getFoo());
+        $this->assertEquals('Averell', $garplies[2]->getFoo());
+    }
+
+    public function testHydrateObjectNull()
+    {
+        $fooBar = $this->getFooBar();
+
+        $data = [
+            'garply' => null
+        ];
+
+        $this->hydrator->hydrateObject($data, $fooBar);
+
+        $garplies = $fooBar->getGarply();
+        $this->assertSame(null, $garplies);
+    }
+
+    public function testHydrateObjectUndefined()
+    {
+        $fooBar = $this->getFooBar();
+
+        $data = [
+            'foo' => 'Lucky Luke',
+        ];
+
+        $this->hydrator->hydrateObject($data, $fooBar);
+
+        $garplies = $fooBar->getGarply();
+        $this->assertCount(3, $garplies);
+        $this->assertEquals('Jack', $garplies[0]->getFoo());
+        $this->assertEquals('William', $garplies[1]->getFoo());
+        $this->assertEquals('Averell', $garplies[2]->getFoo());
+    }
+
+    /**
+     * @expectedException \MetaHydrator\Exception\HydratingException
+     */
+    public function testHydrateObjectInvalid()
+    {
+        $fooBar = $this->getFooBar();
+
+        $data = [
+            'foo' => 'Lucky Luke',
+            'garply' => 'array(0)[]'
+        ];
+
+        try {
+            $this->hydrator->hydrateObject($data, $fooBar);
+        } catch (HydratingException $exception) {
+            $errors = $exception->getErrorsMap();
+            $this->assertArrayHasKey('garply', $errors);
+            $this->assertSame('Invalid array', $errors['garply']);
+            throw $exception;
+        }
+    }
+
+    public function testHydrateNewAssoc()
+    {
+        $this->hydrator->getHandlers()[1]->setAssociative(true);
+        $data = [
+            'foo' => 'Joe',
+            'garply' => [
+                [ 'foo' => 'Jack' ],
+                null,
+                [ 'foo' => 'Averell' ],
+            ]
+        ];
+
+        /** @var FooBar $fooBar */
+        $fooBar = $this->hydrator->hydrateNewObject($data, FooBar::class);
+
+        $this->assertEquals('Joe', $fooBar->getFoo());
+
+        $garplies = $fooBar->getGarply();
+        $this->assertCount(2, $garplies);
+
+        $this->assertEquals('Jack', $garplies[0]->getFoo());
+        $this->assertArrayNotHasKey(1, $garplies);
+        $this->assertEquals('Averell', $garplies[2]->getFoo());
+    }
+
+    public function testHydrateObjectAssoc()
+    {
+        $this->hydrator->getHandlers()[1]->setAssociative(true);
+        $fooBar = $this->getFooBar();
+
+        $data = [
+            'garply' => [
+                0 => [ 'foo' => 'Ma' ],
+                1 => null,
+            ]
+        ];
+
+        $this->hydrator->hydrateObject($data, $fooBar);
+
+        $garplies = $fooBar->getGarply();
+        $this->assertCount(2, $garplies);
+
+        $this->assertEquals('Ma', $garplies[0]->getFoo());
+        $this->assertArrayNotHasKey(1, $garplies);
+        $this->assertEquals('Averell', $garplies[2]->getFoo());
+    }
+
+    /**
+     * @expectedException \MetaHydrator\Exception\HydratingException
+     */
+    public function testHydrateNewSubInvalid()
+    {
+        $data = [
+            'garply' => [
+                0 => [ 'bar' => 'Two' ],
+            ]
+        ];
+
+        try {
+            $this->hydrator->hydrateNewObject($data, FooBar::class);
+        } catch (HydratingException $exception) {
+            $errors = $exception->getErrorsMap();
+            $this->assertArrayHasKey('garply', $errors);
+            $this->assertArrayHasKey(0, $errors['garply']);
+            $this->assertArrayHasKey('bar', $errors['garply'][0]);
+            $this->assertSame('Invalid integer', $errors['garply'][0]['bar']);
+            throw $exception;
+        }
+    }
+
+    /**
+     * @expectedException \MetaHydrator\Exception\HydratingException
+     */
+    public function testHydrateObjectSubInvalid()
+    {
+        $data = [
+            'garply' => [
+                0 => [ 'bar' => 'Two' ],
+            ]
+        ];
+
+        try {
+            $this->hydrator->hydrateObject($data, $this->getFooBar());
+        } catch (HydratingException $exception) {
+            $errors = $exception->getErrorsMap();
+            $this->assertArrayHasKey('garply', $errors);
+            $this->assertArrayHasKey(0, $errors['garply']);
+            $this->assertArrayHasKey('bar', $errors['garply'][0]);
+            $this->assertSame('Invalid integer', $errors['garply'][0]['bar']);
+            throw $exception;
+        }
+    }
+
+    /**
+     * @expectedException \MetaHydrator\Exception\HydratingException
+     */
+    public function testHydrateNewInvalidArray()
+    {
+        $data = [
+            'garply' => [
+                0 => 'FooBar("Ma", 42)',
+            ]
+        ];
+
+        try {
+            $this->hydrator->hydrateObject($data, $this->getFooBar());
+        } catch (HydratingException $exception) {
+            $errors = $exception->getErrorsMap();
+            $this->assertArrayHasKey('garply', $errors);
+            $this->assertArrayHasKey(0, $errors['garply']);
+            $this->assertSame('Invalid FooBar', $errors['garply'][0]);
+            throw $exception;
+        }
+    }
+
+    /**
+     * @expectedException \MetaHydrator\Exception\HydratingException
+     */
+    public function testHydrateObjectValidateThrow()
+    {
+        $this->hydrator->getHandlers()[1]->addValidator(new NotEmptyValidator('FooBars required'));
+        $data = [
+            'garply' => []
+        ];
+
+        try {
+            $this->hydrator->hydrateNewObject($data, FooBar::class);
+        } catch (HydratingException $exception) {
+            $errors = $exception->getErrorsMap();
+            $this->assertArrayHasKey('garply', $errors);
+            $this->assertSame('FooBars required', $errors['garply']);
+            throw $exception;
+        }
+    }
+
+    private function getFooBar()
+    {
+        return new FooBar([
+            'foo' => 'Joe',
+            'garply' => [
+                new FooBar([ 'foo' => 'Jack' ]),
+                new FooBar([ 'foo' => 'William' ]),
+                new FooBar([ 'foo' => 'Averell' ]),
+            ]
+        ]);
+    }
+}


### PR DESCRIPTION
Similarly to the SubHydratingHandler, this handler aims to allow partial edition on objects inside an array field, accessed through the array keys.

Notes:
- By default, the array is non-associative
- Adding a key will create a `new` object.
- All absent keys are ignored (ie the object value is untouched)
- To remove a key, its value must be set to `null` in input data. Therefore, null values are not allowed by this handler