### PR TITLE
Default values support

### DIFF
--- a/src/Handler/SimpleHydratingHandler.php
+++ b/src/Handler/SimpleHydratingHandler.php
@@ -31,17 +31,24 @@ class SimpleHydratingHandler implements HydratingHandlerInterface
     public function setValidators(array $validators) { $this->validators = $validators; }
     public function addValidator(ValidatorInterface $validator) { $this->validators[] = $validator; }
 
+    /** @var mixed */
+    private $defaultValue;
+    public function getDefaultValue() { return $this->defaultValue; }
+    public function setDefaultValue($defaultValue) { $this->defaultValue = $defaultValue; }
+
     /**
      * SimpleHydratingHandler constructor.
      * @param string $key
      * @param ParserInterface $parser
      * @param ValidatorInterface[] $validators
+     * @param mixed $default
      */
-    public function __construct(string $key, ParserInterface $parser, array $validators = [])
+    public function __construct(string $key, ParserInterface $parser, array $validators = [], $defaultValue = null)
     {
         $this->key = $key;
         $this->parser = $parser;
         $this->validators = $validators;
+        $this->defaultValue = $defaultValue;
     }
 
     /**
@@ -56,7 +63,7 @@ class SimpleHydratingHandler implements HydratingHandlerInterface
         if (array_key_exists($this->key, $data)) {
             $rawValue = $data[$this->key];
         } else if ($object === null) {
-            $rawValue = null;
+            $rawValue = $this->defaultValue;
         } else {
             return;
         }

--- a/src/Handler/SubHydratingHandler.php
+++ b/src/Handler/SubHydratingHandler.php
@@ -38,6 +38,11 @@ class SubHydratingHandler implements HydratingHandlerInterface
     public function setValidators(array $validators) { $this->validators = $validators; }
     public function addValidator(ValidatorInterface $validator) { $this->validators[] = $validator; }
 
+    /** @var mixed */
+    protected $defaultValue;
+    public function getDefaultValue() { return $this->defaultValue; }
+    public function setDefaultValue($defaultValue) { $this->defaultValue = $defaultValue; }
+
     /** @var string */
     protected $errorMessage;
     public function getErrorMessage() { return $this->errorMessage; }
@@ -54,15 +59,17 @@ class SubHydratingHandler implements HydratingHandlerInterface
      * @param string $className
      * @param Hydrator $hydrator
      * @param ValidatorInterface[] $validators
+     * @param mixed $defaultValue
      * @param string $errorMessage
      * @param GetterInterface $getter
      */
-    public function __construct(string $key, string $className, Hydrator $hydrator, array $validators = [], string $errorMessage = "", GetterInterface $getter = null)
+    public function __construct(string $key, string $className, Hydrator $hydrator, array $validators = [], $defaultValue = null, string $errorMessage = "", GetterInterface $getter = null)
     {
         $this->key = $key;
         $this->className = $className;
         $this->hydrator = $hydrator;
         $this->validators = $validators;
+        $this->defaultValue = $defaultValue;
         $this->errorMessage = $errorMessage;
         $this->getter = $getter ?? new Getter(false);
     }
@@ -80,7 +87,7 @@ class SubHydratingHandler implements HydratingHandlerInterface
             if ($object !== null) {
                 return;
             } else {
-                $subObject = null;
+                $subObject = $this->defaultValue;
                 $targetData[$this->key] = $subObject;
             }
         } elseif ($data[$this->key] === null) {


### PR DESCRIPTION
Added support for default values (instead of systematic `null`) in handler classes `SimpleHydratingHandler` and `SubHydratingHandler`. Not setting this new variable will not change current behaviour.

***Notice:** Beware of the order of the parameters in* `SubHydratingHandler` *constructor! New parameter* `$defaultValue`* *has not been added at the end of the parameters list, but at the most relevant position, ie after* `$validators`*.*